### PR TITLE
Add macOS build support options

### DIFF
--- a/cmake/moveit_mac.cmake
+++ b/cmake/moveit_mac.cmake
@@ -1,0 +1,14 @@
+set(CMAKE_SYSTEM_NAME Darwin)
+set(CMAKE_OSX_ARCHITECTURES
+    "arm64"
+    CACHE STRING "" FORCE)
+
+# Use libc++ by default
+set(CMAKE_CXX_FLAGS
+    "${CMAKE_CXX_FLAGS} -stdlib=libc++ -Wno-deprecated-declarations")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+
+# Force C++17
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)

--- a/moveit_common/cmake/moveit_package.cmake
+++ b/moveit_common/cmake/moveit_package.cmake
@@ -40,6 +40,14 @@ macro(MOVEIT_PACKAGE)
   set(CMAKE_CXX_STANDARD_REQUIRED ON)
   set(CMAKE_CXX_EXTENSIONS OFF)
 
+  # Build optional components
+  set(_default_BUILD_RUCKIG ON)
+  if(APPLE)
+    add_compile_options(-Wno-deprecated-declarations)
+    set(_default_BUILD_RUCKIG OFF)
+  endif()
+  option(MOVEIT_BUILD_RUCKIG "Build Ruckig support" ${_default_BUILD_RUCKIG})
+
   if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Enable warnings
     add_compile_options(

--- a/moveit_core/CMakeLists.txt
+++ b/moveit_core/CMakeLists.txt
@@ -27,7 +27,10 @@ find_package(pluginlib REQUIRED)
 find_package(random_numbers REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rsl REQUIRED)
-find_package(ruckig REQUIRED)
+
+if(MOVEIT_BUILD_RUCKIG)
+  find_package(ruckig REQUIRED)
+endif()
 find_package(sensor_msgs REQUIRED)
 find_package(shape_msgs REQUIRED)
 find_package(srdfdom REQUIRED)
@@ -103,8 +106,8 @@ install(
           moveit_acceleration_filter_parameters
           moveit_butterworth_filter
           moveit_butterworth_filter_parameters
-          moveit_ruckig_filter
-          moveit_ruckig_filter_parameters
+          $<$<BOOL:${MOVEIT_BUILD_RUCKIG}>:moveit_ruckig_filter>
+          $<$<BOOL:${MOVEIT_BUILD_RUCKIG}>:moveit_ruckig_filter_parameters>
   EXPORT moveit_core_pluginTargets
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
@@ -131,7 +134,7 @@ ament_export_dependencies(
   random_numbers
   rclcpp
   rsl
-  ruckig
+  $<$<BOOL:${MOVEIT_BUILD_RUCKIG}>:ruckig>
   sensor_msgs
   shape_msgs
   srdfdom
@@ -154,6 +157,8 @@ pluginlib_export_plugin_description_file(moveit_core
                                          filter_plugin_acceleration.xml)
 pluginlib_export_plugin_description_file(moveit_core
                                          filter_plugin_butterworth.xml)
-pluginlib_export_plugin_description_file(moveit_core filter_plugin_ruckig.xml)
+if(MOVEIT_BUILD_RUCKIG)
+  pluginlib_export_plugin_description_file(moveit_core filter_plugin_ruckig.xml)
+endif()
 
 ament_package(CONFIG_EXTRAS ConfigExtras.cmake)

--- a/moveit_core/online_signal_smoothing/CMakeLists.txt
+++ b/moveit_core/online_signal_smoothing/CMakeLists.txt
@@ -47,20 +47,22 @@ ament_target_dependencies(
   srdfdom # include dependency from moveit_robot_model
   pluginlib)
 
-add_library(moveit_ruckig_filter SHARED src/ruckig_filter.cpp)
-generate_export_header(moveit_ruckig_filter)
-target_include_directories(
-  moveit_ruckig_filter PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
-set_target_properties(moveit_ruckig_filter
-                      PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
-generate_parameter_library(moveit_ruckig_filter_parameters
-                           src/ruckig_filter_parameters.yaml)
-target_link_libraries(
-  moveit_ruckig_filter moveit_robot_state moveit_ruckig_filter_parameters
-  moveit_smoothing_base ruckig::ruckig)
-ament_target_dependencies(
-  moveit_ruckig_filter srdfdom # include dependency from moveit_robot_model
-  pluginlib)
+if(MOVEIT_BUILD_RUCKIG)
+  add_library(moveit_ruckig_filter SHARED src/ruckig_filter.cpp)
+  generate_export_header(moveit_ruckig_filter)
+  target_include_directories(
+    moveit_ruckig_filter PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+  set_target_properties(moveit_ruckig_filter
+                        PROPERTIES VERSION "${${PROJECT_NAME}_VERSION}")
+  generate_parameter_library(moveit_ruckig_filter_parameters
+                             src/ruckig_filter_parameters.yaml)
+  target_link_libraries(
+    moveit_ruckig_filter moveit_robot_state moveit_ruckig_filter_parameters
+    moveit_smoothing_base ruckig::ruckig)
+  ament_target_dependencies(
+    moveit_ruckig_filter srdfdom # include dependency from moveit_robot_model
+    pluginlib)
+endif()
 
 # Installation
 install(DIRECTORY include/ DESTINATION include/moveit_core)
@@ -70,8 +72,10 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_acceleration_filter_export.h
         DESTINATION include/moveit_core)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_butterworth_filter_export.h
         DESTINATION include/moveit_core)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_ruckig_filter_export.h
-        DESTINATION include/moveit_core)
+if(MOVEIT_BUILD_RUCKIG)
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/moveit_ruckig_filter_export.h
+          DESTINATION include/moveit_core)
+endif()
 
 # Testing
 

--- a/moveit_core/trajectory_processing/CMakeLists.txt
+++ b/moveit_core/trajectory_processing/CMakeLists.txt
@@ -1,7 +1,10 @@
-add_library(
-  moveit_trajectory_processing SHARED
-  src/ruckig_traj_smoothing.cpp src/trajectory_tools.cpp
-  src/time_optimal_trajectory_generation.cpp)
+set(TRAJ_PROCESSING_SRCS src/trajectory_tools.cpp
+                         src/time_optimal_trajectory_generation.cpp)
+if(MOVEIT_BUILD_RUCKIG)
+  list(APPEND TRAJ_PROCESSING_SRCS src/ruckig_traj_smoothing.cpp)
+endif()
+
+add_library(moveit_trajectory_processing SHARED ${TRAJ_PROCESSING_SRCS})
 target_include_directories(
   moveit_trajectory_processing
   PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -17,8 +20,9 @@ ament_target_dependencies(
   urdfdom_headers
   visualization_msgs
   Boost)
-target_link_libraries(moveit_trajectory_processing moveit_robot_state
-                      moveit_robot_trajectory ruckig::ruckig)
+target_link_libraries(
+  moveit_trajectory_processing moveit_robot_state moveit_robot_trajectory
+  $<$<BOOL:${MOVEIT_BUILD_RUCKIG}>:ruckig::ruckig>)
 
 install(DIRECTORY include/ DESTINATION include/moveit_core)
 
@@ -40,10 +44,12 @@ if(BUILD_TESTING)
   target_link_libraries(test_time_optimal_trajectory_generation
                         moveit_test_utils moveit_trajectory_processing)
 
-  ament_add_gtest(test_ruckig_traj_smoothing
-                  test/test_ruckig_traj_smoothing.cpp)
-  target_link_libraries(test_ruckig_traj_smoothing moveit_trajectory_processing
-                        moveit_test_utils)
+  if(MOVEIT_BUILD_RUCKIG)
+    ament_add_gtest(test_ruckig_traj_smoothing
+                    test/test_ruckig_traj_smoothing.cpp)
+    target_link_libraries(test_ruckig_traj_smoothing
+                          moveit_trajectory_processing moveit_test_utils)
+  endif()
 
   ament_add_google_benchmark(robot_trajectory_benchmark
                              test/robot_trajectory_benchmark.cpp)

--- a/moveit_ros/planning/planning_response_adapter_plugins/CMakeLists.txt
+++ b/moveit_ros/planning/planning_response_adapter_plugins/CMakeLists.txt
@@ -1,10 +1,14 @@
 generate_parameter_library(default_response_adapter_parameters
                            res/default_response_adapter_params.yaml)
 
-add_library(
-  moveit_default_planning_response_adapter_plugins SHARED
-  src/add_ruckig_traj_smoothing.cpp src/add_time_optimal_parameterization.cpp
-  src/display_motion_path.cpp src/validate_path.cpp)
+set(ADAPTER_SOURCES src/add_time_optimal_parameterization.cpp
+                    src/display_motion_path.cpp src/validate_path.cpp)
+if(MOVEIT_BUILD_RUCKIG)
+  list(APPEND ADAPTER_SOURCES src/add_ruckig_traj_smoothing.cpp)
+endif()
+
+add_library(moveit_default_planning_response_adapter_plugins SHARED
+            ${ADAPTER_SOURCES})
 
 target_link_libraries(moveit_default_planning_response_adapter_plugins
                       default_response_adapter_parameters)


### PR DESCRIPTION
## Summary
- add a simple macOS toolchain file
- add MOVEIT_BUILD_RUCKIG option in common cmake
- disable Ruckig components when option is off
- silence deprecated warnings on macOS

## Testing
- `pre-commit run --files moveit_common/cmake/moveit_package.cmake moveit_core/CMakeLists.txt moveit_core/online_signal_smoothing/CMakeLists.txt moveit_core/trajectory_processing/CMakeLists.txt moveit_ros/planning/planning_response_adapter_plugins/CMakeLists.txt cmake/moveit_mac.cmake`

------
https://chatgpt.com/codex/tasks/task_e_687fa49c37ec83248724245de59df789